### PR TITLE
Added the ability to override the default user agent and x-hq-client headers

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,2 +1,5 @@
 HQ_BEARER_TOKEN=
 HQ_USER_ID=
+
+HQ_USER_AGENT='hq-viewer/1.2.4 (iPhone; iOS 11.1.1; Scale/3.00)'
+HQ_CLIENT='iOS/1.2.4 b59'

--- a/run.php
+++ b/run.php
@@ -13,14 +13,10 @@ $client = new GuzzleHttp\Client();
 $dotenv = new Dotenv\Dotenv(__DIR__);
 $dotenv->load();
 
-// Allow UA and X-HQ-Cleint to be overriden in env
-$xHqClient = getenv('HQ_CLIENT') ? getenv('HQ_CLIENT') : 'iOS/1.2.4 b59';
-$UserAgent = getenv('HQ_USER_AGENT') ? getenv('HQ_USER_AGENT') : 'hq-viewer/1.2.4 (iPhone; iOS 11.1.1; Scale/3.00)';
-
 $headers = [
-    'User-Agent'    => $UserAgent,
+    'User-Agent'    => getenv('HQ_USER_AGENT') ?? 'hq-viewer/1.2.4 (iPhone; iOS 11.1.1; Scale/3.00)',
     'Authorization' => 'Bearer ' . getenv('HQ_BEARER_TOKEN'),
-    'x-hq-client'   => $xHqClient,
+    'x-hq-client'   => getenv('HQ_CLIENT') ?? 'iOS/1.2.4 b59',
 ];
 
 try {

--- a/run.php
+++ b/run.php
@@ -13,10 +13,14 @@ $client = new GuzzleHttp\Client();
 $dotenv = new Dotenv\Dotenv(__DIR__);
 $dotenv->load();
 
+// Allow UA and X-HQ-Cleint to be overriden in env
+$xHqClient = getenv('HQ_CLIENT') ? getenv('HQ_CLIENT') : 'iOS/1.2.4 b59';
+$UserAgent = getenv('HQ_USER_AGENT') ? getenv('HQ_USER_AGENT') : 'hq-viewer/1.2.4 (iPhone; iOS 11.1.1; Scale/3.00)';
+
 $headers = [
-    'User-Agent'    => 'hq-viewer/1.2.4 (iPhone; iOS 11.1.1; Scale/3.00)',
+    'User-Agent'    => $UserAgent,
     'Authorization' => 'Bearer ' . getenv('HQ_BEARER_TOKEN'),
-    'x-hq-client'   => 'iOS/1.2.4 b59',
+    'x-hq-client'   => $xHqClient,
 ];
 
 try {


### PR DESCRIPTION
Added the ability to override the default user agent and x-hq-client headers. These will change as the mobile app is updated. These values are read from the env file but have sane fallbacks if the value is not in the env file.